### PR TITLE
fix: use a list in the AccountGroupModel toMap as Firestore doesn't handle sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+- Use a list in the AccountGroupModel toMap as Firestore doesn't handle sets
+
 ## 2.4.2
 
 - Remove flutter dependency from pure dart package; part 2: Electric boogaloo.

--- a/packages/flutter_rbac_service/pubspec.yaml
+++ b/packages/flutter_rbac_service/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rbac_service
 description: A new Flutter package project.
-version: 2.4.2
+version: 2.4.3
 repository: https://github.com/Iconica-Development/flutter_rbac
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
 
@@ -13,7 +13,7 @@ dependencies:
 
   flutter_rbac_service_data_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^2.4.2
+    version: ^2.4.3
 
 dev_dependencies:
   flutter_iconica_analysis:

--- a/packages/flutter_rbac_service_data_interface/lib/src/models/account_group_model.dart
+++ b/packages/flutter_rbac_service_data_interface/lib/src/models/account_group_model.dart
@@ -24,7 +24,7 @@ class AccountGroupModel {
 
   Map<String, dynamic> toMap() => <String, dynamic>{
         "name": name,
-        "account_ids": accountIds,
+        "account_ids": accountIds.toList(),
       };
 
   AccountGroupModel copyWith({

--- a/packages/flutter_rbac_service_data_interface/pubspec.yaml
+++ b/packages/flutter_rbac_service_data_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rbac_service_data_interface
 description: A new Flutter package project.
-version: 2.4.2
+version: 2.4.3
 repository: https://github.com/Iconica-Development/flutter_rbac
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
 

--- a/packages/flutter_rbac_service_firebase/pubspec.yaml
+++ b/packages/flutter_rbac_service_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rbac_service_firebase
 description: A new Flutter package project.
-version: 2.4.2
+version: 2.4.3
 repository: https://github.com/Iconica-Development/flutter_rbac
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
 
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_rbac_service_data_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^2.4.2
+    version: ^2.4.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_rbac_service_firebase_admin/pubspec.yaml
+++ b/packages/flutter_rbac_service_firebase_admin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rbac_service_firebase_admin
 description: A new Flutter package project.
-version: 2.4.2
+version: 2.4.3
 repository: https://github.com/Iconica-Development/flutter_rbac
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
 
@@ -11,7 +11,7 @@ dependencies:
   dart_firebase_admin: ^0.4.0
   flutter_rbac_service_data_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^2.4.2
+    version: ^2.4.3
 
 dev_dependencies:
   flutter_iconica_analysis:

--- a/packages/flutter_rbac_view/pubspec.yaml
+++ b/packages/flutter_rbac_view/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rbac_view
 description: A new Flutter package project.
-version: 2.4.2
+version: 2.4.3
 repository: https://github.com/Iconica-Development/flutter_rbac
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
 
@@ -14,10 +14,10 @@ dependencies:
   go_router: ">=12.1.3 <15.0.0"
   flutter_rbac_service_data_interface:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^2.4.2
+    version: ^2.4.3
   flutter_rbac_service:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
-    version: ^2.4.2
+    version: ^2.4.3
   flutter_menu:
     hosted: https://forgejo.internal.iconica.nl/api/packages/internal/pub/
     version: ^0.0.3


### PR DESCRIPTION
Fixes the following error:

```
Invalid argument (Firestore document): Unsupported value type: _Set<String> (found in field account_ids).: _Set len:2
package:dart_firebase_admin/src/google_cloud_firestore/field_value.dart 458:7         _validateUserInput
package:dart_firebase_admin/src/google_cloud_firestore/field_value.dart 384:9         _validateUserInput
package:dart_firebase_admin/src/google_cloud_firestore/write_batch.dart 293:3         _validateDocumentData
package:dart_firebase_admin/src/google_cloud_firestore/write_batch.dart 158:5         WriteBatch.set
package:dart_firebase_admin/src/google_cloud_firestore/reference.dart 301:54          DocumentReference.set
package:flutter_rbac_service_firebase_admin/src/firebase_rbac_datasource.dart 142:52  FirebaseRbacDatasource.setAccountGroup
```